### PR TITLE
megasats: rename buy_ticket to buyticket.

### DIFF
--- a/c680z7fefr/contract.lua
+++ b/c680z7fefr/contract.lua
@@ -8,7 +8,7 @@ function __init__ ()
   }
 end
 
-function buy_ticket ()
+function buyticket ()
   if not account.id then
     error("must be authenticated!")
   end


### PR DESCRIPTION
Because that eases the job for lntxbot parsing (since by default lntxbot converts all _ into spaces).