### PR TITLE
limit to 10000 the amount of satoshis that can be used to buy magda i…

### DIFF
--- a/ckwzob1pkbv/contract.lua
+++ b/ckwzob1pkbv/contract.lua
@@ -36,6 +36,9 @@ function buy()
         error('not authenticated')
     end
     local amount = call.msatoshi 
+    if amount > 10000000 then
+        error('too many sats sent in a single call')
+    end
     _transfer_exec(contract.state.admin, account.id, amount / contract.state.price)
 end
 


### PR DESCRIPTION
this update will limit to 10000 the amount of satoshis that can be used to buy magda in a single call.
this is mandatory to prevent the contract to be exploited and save users funds