### PR TITLE
Add ownership to ChainMarket offers

### DIFF
--- a/c8w0c13v75/contract.lua
+++ b/c8w0c13v75/contract.lua
@@ -15,7 +15,7 @@ function queuepay ()
   end
 
   local addr = call.payload.addr
-  local fee_msat = tonumber(call.payload.fee_msat)
+  local fee_msat = tonumber(call.payload.fee_msat or 0)
   local sat = math.floor((call.msatoshi - fee_msat) / 1000)
 
   if sat < 0 then
@@ -28,13 +28,19 @@ function queuepay ()
   local extra_msat = call.msatoshi - (sat * 1000 + fee_msat)
   fee_msat = fee_msat + extra_msat
 
+  owner=false
+  if account.id then
+    owner=account.id
+  end
+  
   local offer = contract.state[addr] or {
     block = 0,
     sat = 0,
     fee_msat = 0,
     stake = 0,
     waiting = nil,
-    reserved = nil
+    reserved = nil,
+    owner = owner
   }
 
   if offer.reserved then
@@ -51,6 +57,21 @@ function queuepay ()
   offer.block = tip
 
   contract.state[addr] = offer
+end
+
+function revoke () 
+	local addr = call.payload.addr
+	local offer = contract.state[addr]
+	if not addr or
+    not account.id or
+		not offer or 
+    offer.reserved or
+    offer.owner ~=account.id
+  then
+		error("nil")
+	end
+  contract.send(offer.owner, offer.sat * 1000 + offer.fee_msat)
+	contract.state[addr]=nil
 end
 
 function reserve ()


### PR DESCRIPTION
now users can optionally authenticate when they call queuepay to create a new offer
their account.id will be saved in the offer 
and they can eventually revoke that. 
if the offer already exist owner can't be changed

if user is not authenticated 
or offer is reserved 
the offer can not be revoked. 
 
also fixed a bug to prevent the contract to fail if no fee_msat is set now it set fee_msat to 0 default
https://test.etleneum.com/#/contract/cnsewt3au2m
